### PR TITLE
login screen change label from username or email to email

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -19,7 +19,7 @@
                                 v-model="usernameOrEmail"
                                 outlined
                                 autofocus
-                                label="Email or username"
+                                label="Email"
                                 @keydown.enter="setUsernameOrEmail"
                                 :error-messages="errorMsg"
                                 id="input-email-or-username"
@@ -57,7 +57,7 @@
                         <v-text-field
                                 append-icon="mdi-check"
                                 v-model="usernameOrEmail"
-                                label="Email or username"
+                                label="Email"
                                 readonly
                                 outlined
                                 id="input-email-or-username"


### PR DESCRIPTION
Changing label only; leaving functionality as is so login doesn't break for any existing non-email usernames.