### PR TITLE
Remove account mgmt dropdown and show logout icon in main menu

### DIFF
--- a/src/components/AppBar.vue
+++ b/src/components/AppBar.vue
@@ -73,8 +73,6 @@
                 <span>Purchase</span>
             </v-btn>
 
-
-
             <v-btn
                     class="breadcrumbs"
                     text
@@ -84,36 +82,29 @@
             >
                 Log in
             </v-btn>
-            <v-menu offset-y v-if="isLoggedIn">
-                <template
-                        v-slot:activator="{ on }">
-                    <v-btn icon
-                           class="px-2"
-                           v-on="on"
-                    >
+
+            <v-tooltip v-if="isLoggedIn" bottom color="#333" max-width="200">
+                <template v-slot:activator="{on}">
+                    <v-btn icon v-on="on" icon to="/u">
                         <v-icon>mdi-account-outline</v-icon>
                     </v-btn>
                 </template>
-                <v-list subheader>
-                    <v-subheader>Hi, {{ userName }}!</v-subheader>
-                    <v-list-item to="/u">
-                        <v-list-item-icon>
-                            <v-icon>mdi-account-outline</v-icon>
-                        </v-list-item-icon>
-                        <v-list-item-title>
-                            My account info
-                        </v-list-item-title>
-                    </v-list-item>
-                    <v-list-item @click="logout">
-                        <v-list-item-icon>
-                            <v-icon>mdi-logout</v-icon>
-                        </v-list-item-icon>
-                        <v-list-item-title>
-                            Log out
-                        </v-list-item-title>
-                    </v-list-item>
-                </v-list>
-            </v-menu>
+                <div>
+                    Manage your account info
+                </div>
+            </v-tooltip>
+
+            <v-tooltip v-if="isLoggedIn" bottom color="#333" max-width="200">
+                <template v-slot:activator="{on}">
+                    <v-btn icon v-on="on" @click="logout">
+                        <v-icon>mdi-logout</v-icon>
+                    </v-btn>
+                </template>
+                <div>
+                    Logout
+                </div>
+            </v-tooltip>
+
             <v-btn icon href="https://intercom.help/get-unsub/en" target="_blank">
                 <v-icon>mdi-help-circle-outline</v-icon>
             </v-btn>


### PR DESCRIPTION
In the main menu for logged in users:
- Remove dropdown menu beneath person icon and send user to Your account (/u) on click
- Add logout icon
- Add tooltips for person and logout icons (Manage your account info / Logout)
- Standardize tooltip text for person icon to use "your" instead of "my" (since "your" is used on /u)

<img width="302" alt="manage-info" src="https://user-images.githubusercontent.com/8026886/103498401-3e7dbf80-4e0a-11eb-8aed-ff3dfb4e8d46.png">

<img width="259" alt="logout" src="https://user-images.githubusercontent.com/8026886/103498411-49d0eb00-4e0a-11eb-9be2-f9473e99eb2c.png">
