### PR TITLE
Standardize toolbar and add breadcrumbs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -164,6 +164,10 @@
 
     }
 
+    .v-breadcrumbs {
+        padding-left: 0;
+    }
+
 
     .toolbar-summary {
         display: inline-flex;

--- a/src/components/AppBar.vue
+++ b/src/components/AppBar.vue
@@ -1,12 +1,10 @@
 <template>
     <v-toolbar
-            :color="backgroundColor"
-            :dark="institutionIsConsortium"
+            color="white"
             :flat="isLandingPage"
     >
         <router-link to="/">
-            <img v-if="!institutionIsConsortium"  class="mt-2" style="width:130px;" src="../assets/unsub-logo.png" alt="" />
-            <img v-if="institutionIsConsortium"  class="mt-2" style="width:130px;" src="../assets/unsub-logo-white.png" alt="" />
+            <img class="mt-2" style="width:130px;" src="../assets/unsub-logo.png" alt="" />
         </router-link>
 <!--        <v-toolbar-title class="headline">-->
 <!--        </v-toolbar-title>-->
@@ -29,38 +27,31 @@
                    active-class="no-active"
             >
                 <div>
-                    <div v-if="institutionIsConsortium" class="body-2 font-weight-bold">
-                        Consortium:
+                    <v-chip
+                        v-if="institutionIsConsortium"
+                        x-small
+                        color="primary"
+                    >
+                        Consortium
+                    </v-chip>
+                    <v-chip
+                        x-small
+                        v-if="!institutionIsConsortium"
+                        outlined
+                    >
+                        Institution
+                    </v-chip>
+                    <!--<div v-if="institutionIsConsortium" class="body-2 font-weight-bold" style="line-height:initial">
+                        Consortium
                     </div>
-                    <div class="title font-weight-regular">
+                    <div v-if="!institutionIsConsortium" class="body-2 font-weight-bold line-height-reset" style="line-height:initial">
+                        Institution
+                    </div>-->
+                    <div class="title font-weight-regular line-height-reset" style="line-height:initial">
                         {{ institutionName }}
                     </div>
                 </div>
             </v-btn>
-
-
-<!--            not using breadcrumbs right now. -->
-            <div class="d-none">
-                <v-btn v-if="institutionName"
-                       class="px-3"
-                       :class="{'pr-0': !!publisherName}"
-                       text
-                       :to="`/i/${institutionId}`"
-                >
-                    <span class="title font-weight-regular">
-                        {{ institutionName }}
-                    </span>
-                    <v-icon color="grey" v-if="publisherName"  class="pl-2">mdi-chevron-right</v-icon>
-                </v-btn>
-                <v-btn v-if="publisherName" class="px-2" text :to="`/i/${institutionId}/p/${publisherId}`">
-    <!--                <v-icon color="grey"  class="pr-2">mdi-bank</v-icon>-->
-                    <span class="title font-weight-regular">
-                        {{ publisherName }}
-
-                    </span>
-                </v-btn>
-
-            </div>
         </v-toolbar-items>
 
         <v-spacer/>
@@ -183,10 +174,7 @@
             },
             selectedScenario() {
                 return this.$store.getters.selectedScenario
-            },
-            backgroundColor(){
-                return (this.institutionIsConsortium) ? "primary" : "white"
-            },
+            }
         },
         created() {
         },
@@ -213,6 +201,4 @@
         display: flex;
         justify-content: space-between;
     }
-
-
 </style>

--- a/src/views/Publisher.vue
+++ b/src/views/Publisher.vue
@@ -18,11 +18,11 @@
 
 
         <div class="loaded" v-if="loadingPercent === 100">
-            <router-link class="text--secondary low-key-link" :to="`/i/${institutionId}`">
-                <strong>‹</strong>
-                Back <span v-if="institutionName">to {{institutionName}}</span>
-            </router-link>
-            <div class="page-title mt-8 mb-4 d-flex">
+            <v-breadcrumbs
+                class="pl-0"
+                :items="breadcrumbs"
+            ></v-breadcrumbs>
+            <div class="page-title mt-4 mb-4 d-flex">
                 <v-avatar tile size="60" class="mt-1 mr-3">
                     <img height="60px" :src="publisherLogo">
                 </v-avatar>
@@ -182,6 +182,24 @@
                 "publisherApcIsLoading",
 
             ]),
+            breadcrumbs () {
+                if(this.institutionName && this.publisherName){
+                    return [
+                        {
+                            text: this.institutionName,
+                            disabled: false,
+                            href: '/i/' + this.institutionId
+                        },
+                        {
+                            text: this.publisherName,
+                            disabled: true,
+                            href: '/i/' + this.institutionId + '/p/' + this.publisherId
+                        }
+                    ]
+                } else {
+                    return []
+                }
+            },
             tabItems() {
                 if (this.institutionIsConsortium) {
                     return ["Forecasts"]

--- a/src/views/Scenario.vue
+++ b/src/views/Scenario.vue
@@ -19,15 +19,12 @@
 
         <div v-if="!selectedScenarioIsLoading">
             <v-container>
-
-                <router-link
-                        v-if="publisherId && institutionId"
-                        class="text--secondary low-key-link"
-                        :to="`/i/${institutionId}/p/${publisherId}`">
-                    <strong>‹</strong>
-                    Back <span v-if="publisherName">to {{publisherName}}</span>
-                </router-link>
-                <div class="page-title mt-8 d-flex">
+                <v-breadcrumbs
+                    class="pl-0"
+                    :items="breadcrumbs"
+                >
+                </v-breadcrumbs>
+                <div class="page-title mt-4 d-flex">
                     <div class="text">
                         <div class="body-2">
                             <span>
@@ -401,6 +398,7 @@
                 'selectedScenarioIsLoading',
                 'institutionId',
                 'institutionIsConsortium',
+                'institutionName',
                 'scenarioName',
                 'scenarioMemberInstitutions',
                 'scenarioId',
@@ -419,7 +417,29 @@
 
             readyStatus(){
             },
-
+            breadcrumbs () {
+                if(this.institutionName && this.publisherName){
+                    return [
+                        {
+                            text: this.institutionName,
+                            disabled: false,
+                            href: '/i/' + this.institutionId
+                        },
+                        {
+                            text: this.publisherName,
+                            disabled: false,
+                            href: '/i/' + this.institutionId + '/p/' + this.publisherId
+                        },
+                        {
+                            text: this.scenarioName,
+                            disabled: true,
+                            href: '/i/' + this.institutionId + '/p/' + this.publisherId + '/s' + this.scenarioId
+                        }
+                    ]
+                } else {
+                    return []
+                }
+            },
             account() {
                 return this.$store.state.account
             },

--- a/src/views/Scenario.vue
+++ b/src/views/Scenario.vue
@@ -20,6 +20,7 @@
         <div v-if="!selectedScenarioIsLoading">
             <v-container>
                 <v-breadcrumbs
+                    v-if="breadcrumbs.length > 0"
                     class="pl-0"
                     :items="breadcrumbs"
                 >


### PR DESCRIPTION
- Make toolbar background same for both consortium and non-consortium institutions
- Add Consortium/Institution label in toolbar as chip. 
_Note: I'm not totally sold on the chips, but in my experience building apps that consortia use (and support their institutions in using), some differentiation between institution and consortia accounts is helpful to avoid confusion. Happy to rework and ditch the chips, though._
- Replace "Back to ..." on package and scenario pages with true breadcrumbs
<img width="468" alt="toolbar-not-consortium" src="https://user-images.githubusercontent.com/8026886/104144957-ea835580-538a-11eb-9aac-529ea5c37fa5.png">
<img width="384" alt="toolbar-consortium" src="https://user-images.githubusercontent.com/8026886/104144962-eeaf7300-538a-11eb-984d-77210787559b.png">
<img width="449" alt="breadcrumbs-package" src="https://user-images.githubusercontent.com/8026886/104144970-f40cbd80-538a-11eb-8ef5-9f9c13749a8c.png">
<img width="521" alt="breadcrumbs-scenario" src="https://user-images.githubusercontent.com/8026886/104144978-f7a04480-538a-11eb-8964-bac7e7729226.png">


