### PR TITLE
fix costPercent in Scenario.vue

### DIFF
--- a/src/views/Scenario.vue
+++ b/src/views/Scenario.vue
@@ -478,7 +478,11 @@ export default {
       return this.$store.getters.subrJournalsCount
     },
     costPercent() {
-      return 100 * this.costTotal / this.publisherBigDeal5YearAnnualCost
+      if (this.institutionIsConsortium) {
+        return 100 * this.costTotal / this.scenario.saved.configs.cost_bigdeal
+      } else {
+        return 100 * this.costTotal / this.publisherBigDeal5YearAnnualCost
+      }
     },
     subscribedJournals() {
       return this.journals.filter(j => !!j.subscribed || j.customSubscribed)


### PR DESCRIPTION
fixes ourresearch/unsub-private#11

- use if/else block on whether institution is consortium or not
- if consortium use big deal cost from scenario.saved.configs.cost_bigdeal
- if not consortium use original value (publisherBigDeal5YearAnnualCost)